### PR TITLE
Update help.js

### DIFF
--- a/29-Dynamic-Help-Menu/commands/help.js
+++ b/29-Dynamic-Help-Menu/commands/help.js
@@ -2,46 +2,46 @@ const loadCommands = require('./load-commands')
 const { prefix } = require('../config.json')
 
 module.exports = {
-  commands: ['help', 'h'],
-  description: "Describes all of this bot's commands",
-  callback: (message, arguments, text) => {
-    let reply = 'I am the tutorial bot, here are my supported commands:\n\n'
+    commands: ['help', 'h'],
+    description: "Describes all of this bot's commands",
+    callback: (message, arguments, text) => {
+        let reply = 'Here are my supported commands:\n\n'
 
-    const commands = loadCommands()
+        const commands = loadCommands()
 
-    for (const command of commands) {
-      // Check for permissions
-      let permissions = command.permission
+        for (const command of commands) {
+            // Check for permissions
+            let commandPermissions = command.permissions
 
-      if (permissions) {
-        let hasPermission = true
-        if (typeof permissions === 'string') {
-          permissions = [permissions]
+            if (commandPermissions) {
+                let hasPermission = true
+                if (typeof commandPermissions === 'string') {
+                    commandPermissions = [commandPermissions]
+                }
+
+                for (const permission of commandPermissions) {
+                    if (!message.member.hasPermission(permission)) {
+                        hasPermission = false
+                        break
+                    }
+                }
+
+                if (!hasPermission) {
+                    continue
+                }
+            }
+
+            // Format the text
+            const mainCommand =
+                typeof command.commands === 'string'
+                    ? command.commands
+                    : command.commands[0]
+            const args = command.expectedArgs ? ` ${command.expectedArgs}` : ''
+            const { description } = command
+
+            reply += `**${prefix}${mainCommand}${args}** = ${description}\n`
         }
 
-        for (const permission of permissions) {
-          if (!message.member.hasPermission(permission)) {
-            hasPermission = false
-            break
-          }
-        }
-
-        if (!hasPermission) {
-          continue
-        }
-      }
-
-      // Format the text
-      const mainCommand =
-        typeof command.commands === 'string'
-          ? command.commands
-          : command.commands[0]
-      const args = command.expectedArgs ? ` ${command.expectedArgs}` : ''
-      const { description } = command
-
-      reply += `**${prefix}${mainCommand}${args}** = ${description}\n`
-    }
-
-    message.channel.send(reply)
-  },
+        message.channel.send(reply)
+    },
 }

--- a/29-Dynamic-Help-Menu/commands/help.js
+++ b/29-Dynamic-Help-Menu/commands/help.js
@@ -1,11 +1,10 @@
 const loadCommands = require('./load-commands')
 const { prefix } = require('../config.json')
 
-module.exports = {
-    commands: ['help', 'h'],
-    description: "Describes all of this bot's commands",
-    callback: (message, arguments, text) => {
-        let reply = 'Here are my supported commands:\n\n'
+  commands: ['help', 'h'],
+  description: "Describes all of this bot's commands",
+  callback: (message, arguments, text) => {
+    let reply = 'I am the tutorial bot, here are my supported commands:\n\n'
 
         const commands = loadCommands()
 

--- a/29-Dynamic-Help-Menu/commands/help.js
+++ b/29-Dynamic-Help-Menu/commands/help.js
@@ -1,10 +1,11 @@
 const loadCommands = require('./load-commands')
 const { prefix } = require('../config.json')
 
-  commands: ['help', 'h'],
-  description: "Describes all of this bot's commands",
-  callback: (message, arguments, text) => {
-    let reply = 'I am the tutorial bot, here are my supported commands:\n\n'
+module.exports = {
+    commands: ['help', 'h'],
+    description: "Describes all of this bot's commands",
+    callback: (message, arguments, text) => {
+        let reply = 'I am the tutorial bot, here are my supported commands:\n\n'
 
         const commands = loadCommands()
 


### PR DESCRIPTION
`let permissions = command.permission ` 

Will cause this to always display all commands, regardless of the permissions of the user, irrespective of their actual permissions as both the add command, add currency command + the default module.exports use the key value pair labelled "permissions" not permission. Changing to be

`let commandPermissions = command.permissions` 

resolves this by pulling the correct key/value pair and as such commands will not be shown if the user doesn't have the permissions.