### PR TITLE
Removed the capitalization of expectedArgs

### DIFF
--- a/82-Slash-Commands/commands/ping.js
+++ b/82-Slash-Commands/commands/ping.js
@@ -5,7 +5,7 @@ module.exports = {
   testOnly: true,
   description: 'A simple ping pong command!!!',
   minArgs: 2,
-  expectedArgs: '<Name> <Age> [Country]',
+  expectedArgs: '<name> <age> [country]',
   callback: ({ message, args }) => {
     const embed = new MessageEmbed().setTitle('Example').setDescription('pong')
 


### PR DESCRIPTION
This example errors out when `expectedArgs` are capitalized as noted in this [discord thread](https://discord.com/channels/464316540490088448/818363058656509993/848026674183798825).


Example or Error from the [current master branch](https://github.com/AlexzanderFlores/Worn-Off-Keys-Discord-Js/commit/baa1d9e19f0424a191565eff8ba17ec7b0b72e6d):
```bash
(node:57462) UnhandledPromiseRejectionWarning: DiscordAPIError: Invalid Form Body
options[0].name: Command name is invalid
options[1].name: Command name is invalid
options[2].name: Command name is invalid
    at RequestHandler.execute (/Users/gndclouds/Downloads/Worn-Off-Keys-Discord-Js-master/82-Slash-Commands/82-Slash-Commands/node_modules/discord.js/src/rest/RequestHandler.js:154:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async RequestHandler.push (/Users/gndclouds/Downloads/Worn-Off-Keys-Discord-Js-master/82-Slash-Commands/82-Slash-Commands/node_modules/discord.js/src/rest/RequestHandler.js:39:14)
(node:57462) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:57462) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```